### PR TITLE
CSS: Fix headlines indent in content

### DIFF
--- a/hugo/static/css/mumble.css
+++ b/hugo/static/css/mumble.css
@@ -25,11 +25,14 @@ aside {
 	height: 100%;
 }
 
+header h1 {
+	padding-left: 10px;
+}
+
 h1 {
 	grid-template: "header";
 	font-size: 200%;
 	align-self: center;
-	padding-left: 10px;
 }
 
 h1 a {


### PR DESCRIPTION
The left padding is required right now for the logo headline,
but before this change breaks the layout continuity in content.