### PR TITLE
Menu: Link Documentation menu item to wiki

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -24,7 +24,7 @@ disableKinds = ["taxonomy","taxonomyTerm"]
     title = "Documentation"
     weight = 3
     identifier = "docs"
-    url = "/docs"
+    url = "https://wiki.mumble.info/"
 
 [[menu.main]]
     title = "Blog"


### PR DESCRIPTION
For now, as we have no in-website documentation yet, make the
Documentation menu item link to our documentation wiki.