### PR TITLE
Layout: Drop footer copyright notice

### DIFF
--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -7,6 +7,5 @@
             {{ end }}
         </ul>
         {{ end }}
-        <p class="copyleft">Copyright (c) {{ now.Format "2006" }} The Mumble Developers</p>
     </div>
 </footer>


### PR DESCRIPTION
A copyright notice is not necessary to receive and retain copyright.

A copyright year is typically/originally added so users may see when the
copyright expires.
However, nobody will wait for copyright on our website to expire to make
use of its content.
And if necessary, the source repository retains a history.

I also do not see how the notice could be useful when saving or printing
the website. I doubt that’s a typical use case, and the above
argumentation applies.

I am also wondering if always printing the current year is correct.
Does the copyright start when we distribute/publish, even when the
content does not change?

The notice before this change (footer at the bottom of the page):

![mumble-www-footer-copyright-notice](https://user-images.githubusercontent.com/93181/64075143-cef73d80-ccb4-11e9-90b7-c378d0bf1ac4.png)
