### PR TITLE
Add download links for AppImage

### DIFF
--- a/hugo/assets/css/downloads.scss
+++ b/hugo/assets/css/downloads.scss
@@ -24,6 +24,10 @@
 	margin: 0 auto;
 }
 
+.os-appimage {
+	background-image: url(icons/appimage.svg);
+}
+
 .os-windows {
 	background-image: url(icons/windows.svg);
 }

--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -17,6 +17,12 @@ Version 1.3.0 is the latest stable version of Mumble and was released on Septemb
         </a>
     </div>
     <div class="download-box">
+        <a href="appimage-x64">
+            <span class="os os-appimage" aria-hidden="true"></span>
+            <span class="os-name">AppImage x64</span>
+        </a>
+    </div>
+    <div class="download-box">
         <a href="osx">
             <span class="os os-mac" aria-hidden="true"></span>
             <span class="os-name">macOS</span>
@@ -82,6 +88,7 @@ When a new feature release is published the snapshots will naturally transform i
     <tr>
         <th>Windows 64-bit</th>
         <th>Windows 32-bit</th>
+        <th>AppImage x64</th>
         <th>macOS</th>
         <th>macOS (Universal, Legacy)</th>
         <th>Ubuntu</th>
@@ -94,6 +101,9 @@ When a new feature release is published the snapshots will naturally transform i
         </td>
         <td>
             <a href="windows-32/snapshot">.msi</a>
+        </td>
+        <td>
+            <a href="appimage-x64/snapshot">.AppImage</a>
         </td>
         <td>
             <a href="osx/snapshot">.dmg</a>

--- a/hugo/static/css/icons/appimage.svg
+++ b/hugo/static/css/icons/appimage.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="448" height="512" version="1">
+  <g transform="translate(0 464)">
+    <rect y="-432" ry="26" rx="26" height="448" width="448"/>
+    <path style="marker:none" d="M188-402v69h-39l75 81 75-81h-39v-69zm24 170c-2 0-3 3-3 7v26c-8 1-15 5-22 9l-18-18c-3-3-6-5-7-3l-17 17c-2 1 0 4 3 7l18 18c-4 7-8 14-9 22h-26c-4 0-7 1-7 3v24c0 2 3 3 7 3h26c1 8 5 15 9 22l-18 18c-3 3-5 6-3 7l17 17c1 2 4 0 7-3l18-18c7 4 14 8 22 9v26c0 4 1 7 3 7h24c2 0 3-3 3-7v-26c8-1 15-5 22-9l18 18c3 3 6 5 7 3l17-17c2-1 0-4-3-7l-18-18c4-7 8-14 9-22h26c4 0 7-1 7-3v-24c0-2-3-3-7-3h-26c-1-8-5-15-9-22l18-18c3-3 5-6 3-7l-17-17c-1-2-4 0-7 3l-18 18c-7-4-14-8-22-9v-26c0-4-1-7-3-7z" overflow="visible" fill="#fff" stroke="#fff"/>
+    <path style="marker:none" d="M224-167c19 0 35 16 35 35s-16 35-35 35-35-16-35-35 16-35 35-35z" overflow="visible"/>
+  </g>
+</svg>


### PR DESCRIPTION
The icon is based on https://github.com/AppImage/AppImageKit/blob/master/resources/appimagetool.svg.

I only kept the rounded square, the arrow, the gear and the circle in it.

- The colors are changed (pure black for the square and circle, pure white for everything else).
- The document size is changed to match the other icons' resolution (448x512).
- The square size is increased as much as possible (448x448).
- The arrow and gear are aligned and resized.