### PR TITLE
Docs: Add documentation section and migrate Ice documentation

### DIFF
--- a/hugo/config/_default/menus.toml
+++ b/hugo/config/_default/menus.toml
@@ -14,7 +14,7 @@
     title = "Documentation"
     weight = 3
     identifier = "docs"
-    url = "https://wiki.mumble.info/"
+    url = "/documentation"
 
 [[main]]
     title = "Blog"

--- a/hugo/content/documentation/_index.md
+++ b/hugo/content/documentation/_index.md
@@ -1,0 +1,9 @@
+---
+title: Mumble Documentation
+date: 2019-10-22
+---
+The Mumble project consists of many things, and so the documentation has separate content for each concern and sub-project.
+
+Most of our documentation is in our Wiki at [wiki.mumble.info](https://wiki.mumble.info/wiki/Main_Page). We are in the process of moving (some) of that documentation onto this website, here under [www.mumble.info/documentation]({{< relref "/documentation" >}}).
+
+If you do not find what you are looking for here then please refer to the [documentation wiki](https://wiki.mumble.info/wiki/Main_Page) and navigate or search for what you are looking for there.

--- a/hugo/content/documentation/mumble-server/scripting/_index.md
+++ b/hugo/content/documentation/mumble-server/scripting/_index.md
@@ -1,0 +1,24 @@
+---
+title: Mumble Server Scripting
+date: 2019-10-27
+---
+The Mumble Server can listen to commands from other applications to allow scripting specific actions and functionality on triggers.
+
+For example:
+
+* {{< wiki "3rd_Party_Applications#Authenticators" "Authenticators" />}} can be used to authenticate connecting users through an existing database (for example Active Directory, a Forum Database, Website Database, etc)
+* Context Menu extensions can provide additional context menu (right click) actions to users
+* Adjust user state
+* Channel Viewers (online users)
+  * Connected directly
+  * Making use of {{< wiki "Channel Viewer Protocol" "Channel Viewer Protocol" />}} provider
+* Management of server, user or database state, for example with webinterface/website
+
+Different technologies can be used for scripting. Ice is the most stable and complete one.
+
+| Technology | State | Documentation |
+|---|---|---|
+| Ice | Stable | [Ice Scripting]({{< relref "ice" >}}), [Slice Types Docs](/documentation/slice/) |
+| <abbr title="Command Line Interface">CLI</abbr> | Stable | {{< wiki "RPC subcommand" />}} |
+| DBus | Obsolete, Incomplete | {{<wiki DBus />}} |
+| GRPC | Unreleased, Buildable, Incomplete | {{< wiki GRPC />}} |

--- a/hugo/content/documentation/mumble-server/scripting/ice/_index.md
+++ b/hugo/content/documentation/mumble-server/scripting/ice/_index.md
@@ -1,0 +1,21 @@
+---
+title: Mumble Server Scripting with Ice
+date: 2019-10-27
+---
+The Mumble Server supports remote scripting using the [ZeroC Ice](https://zeroc.com/products/ice) RPC protocol and framework.
+
+There are bindings (libraries) for C++, Java, .NET, Python, PHP and Ruby, and this is supported on all our platforms (Win32, Linux and OSX). Ice works locally and also over a network. This means you can create a web application that interfaces with a Murmur process running on the same or other machines.
+
+Note that after you have ICE set up on your machine, you can install a {{< wiki "3rd_Party_Applications#Web-Interfaces" "web interface" />}}.
+
+## Developing for the Murmur Ice interface
+
+How to use Ice differs from language to language. The parameters and method names will remain the same, but the syntax will naturally be different. Murmur will, by default, open up an adapter on port `6502` (or `10000` for homedir installs), which has a single accessible object named `Meta`. This is the Meta server, and from it you can retrieve adapters for any configured server. (One server process can run multiple Mumble servers.)
+
+The ice interface is fully documented, and you can browse the [generated documentation](/documentation/slice/).
+
+Further detailed, feature and language specific documentation is available in subpages.
+
+{{< aside >}}
+This content released under [Creative Commons Attribution Share Alike](http://creativecommons.org/licenses/by-sa/2.5/) unless otherwise noted. This content is based on {{< wiki Ice />}}.
+{{< /aside >}}

--- a/hugo/content/documentation/mumble-server/scripting/ice/compiling.md
+++ b/hugo/content/documentation/mumble-server/scripting/ice/compiling.md
@@ -1,0 +1,89 @@
+---
+title: Compiling Ice
+date: 2019-10-27
+weight: 10
+---
+On some platforms there are no officially supported binaries available. In that case you will either have to change your platform or compile Ice yourself.
+
+## Building Ice on Redhat/CentOS machines
+
+**Note: 3.3.1 is no longer the current version of Ice. Feel free to try this guide with the new version and update it if it works, or fix it if it does not.**
+
+### 1. Download and unpack ICE
+
+```bash
+wget http://www.zeroc.com/download/Ice/3.3/Ice-3.3.1.tar.gz
+tar -xzf Ice-3.3.1.tar.gz
+```
+
+### 2. Compile the ICE CPP bindings
+
+(these are required for all other bindings)
+
+You will need `mcpp-devel` from the Zeroc website installed to compile.
+<http://www.zeroc.com/download.html> - Ctrl-F and look for `mcpp-devel`. There is a big package of various Ice RPMs to download. You will install a few dependencies, along with the `mcpp-devel package`.
+
+```bash
+cd Ice-3.3.1/cpp
+make
+```
+
+(wait 20 minutes)
+
+```bash
+sudo make install
+```
+
+### 3. Compile and install the Ice bindings for your preferred language
+
+For example, to install Ruby bindings:
+
+```bash
+cd ../rb
+make
+sudo make install
+```
+
+### 4. Export the paths for your newly-installed libraries
+
+These will be different for each language - check the `INSTALL` or `README` files in each language’s subdirectory for exact instructions.
+
+For Ruby:
+
+```bash
+export RUBYLIB=/opt/Ice-3.3.1/ruby:$RUBYLIB
+export LD_LIBRARY_PATH=/opt/Ice-3.3.1/lib:LD_LIBRARY_PATH
+```
+
+If you don't want to always have to keep running those export lines, also add them to your ~/.bashrc:
+
+```bash
+export RUBYLIB=/opt/Ice-3.3.1/ruby:$RUBYLIB
+export LD_LIBRARY_PATH=/opt/Ice-3.3.1/lib:LD_LIBRARY_PATH
+```
+
+### Verifying
+
+At this point, Ice should be available to your language (in this case, Ruby):
+
+```bash
+$ irb
+irb(main):001:0> require 'Ice'
+=> true
+```
+
+### Generate the Slice file for your language
+
+To generate it for ruby, we use the `slice2rb` program, which is in the `Ice/cpp/bin` directory. Similar binaries for your language of choice will be there, too.
+
+```bash
+wget -O Murmur.ice "https://raw.github.com/mumble-voip/mumble/master/src/murmur/Murmur.ice"
+../cpp/bin/slice2rb Murmur.ice
+cp Murmur.rb #{MANAGER_ROOT}/vendor/ice
+```
+
+Congratulations! Ice should be set up and fully functional.
+
+{{< aside >}}
+This content released under [Creative Commons Attribution Share Alike](http://creativecommons.org/licenses/by-sa/2.5/) unless otherwise noted. This content is based on {{< wiki Ice />}}.
+{{< /aside >}}

--- a/hugo/content/documentation/mumble-server/scripting/ice/glacier2.md
+++ b/hugo/content/documentation/mumble-server/scripting/ice/glacier2.md
@@ -1,0 +1,88 @@
+---
+title: Using Glacier2 with Ice
+date: 2019-10-27
+weight: 100
+---
+**NOTE: Since Mumble 1.2.2 you can set `icesecretread` and `icesecretwrite` in your server configuration and use it as a password. This is a lot easier to set up and use than Glacier2.**
+
+**Glacier2** is a Ice **routing and firewall utility**, and allows you to securely run the server on one machine and murmur on another. Note that if both server and client are on a secure LAN, you can just use `iptables` to protect the Ice port, which is a lot easier than setting up Glacier2.
+
+The examples here assume that `1.2.3.4` is the public IP address of the server running Murmur. We're going to use the username `magic` with the password `pink`.
+
+## Configuring Glacier2
+
+Create a config file called `config.glacier2` and put the following in it:
+
+```ini
+Glacier2.Client.Endpoints=tcp -h 1.2.3.4 -p 4063
+Glacier2.SessionTimeout=60
+Glacier2.CryptPasswords=passwords.txt
+```
+
+Your endpoint host should be the public IP that you are running Glacier on. If you don't specify a client via `-h`, then Glacier will bind to all listening interfaces.
+
+Then, create a password hash using the OpenSSL utility.
+
+```bash
+openssl passwd pink
+```
+
+this will spit out a hash, which looks something like `CTThafhdv9Lz2`
+
+Create a file called `passwords.txt` containing:
+
+```bash
+magic CTThafhdv9Lz2
+```
+
+Start glacier2 as this:
+
+```bash
+glacier2router --Ice.Config=config.glacier2
+```
+
+You will need to have Ice installed ([download](https://zeroc.com/downloads/ice)). `glacier2router` is a binary that is located in `<location_of_Ice_installation>/bin/glacier2router.exe`.
+
+## Configuring Murmur
+
+There is nothing to do in murmur. Seriously. Leave the default setting of binding to `127.0.0.1` alone.
+
+## Configuring Client (PHP)
+
+This is where it starts getting slightly ugly. Note that this requires Ice >= 3.3.1, as Ice 3.3.0 has a bug in it which prevents this from working. The following is the adaptation necessary to `weblist.php` to get it to work:
+
+```php
+try {
+  $router = $ICE->stringToProxy("Glacier2/router:tcp -p 4063 -h 1.2.3.4");
+  $router = $router->ice_uncheckedCast("::Glacier2::Router")->ice_router(null);
+  $session = $router->createSession("magic", "pink");
+  $base = $ICE->stringToProxy("Meta:tcp -h 127.0.0.1 -p 6502")->ice_router($router);
+  $meta = $base->ice_checkedCast("::Murmur::Meta")->ice_router($router);
+  …
+```
+
+For each object you get a proxy to (including the return from `$meta->getServer`), you need to add `->ice_router($router)`
+
+## Configuring Client (Ruby)
+
+There is a set of classes for easily working with Ice directly and through Glacier [available at GitHub](https://github.com/cheald/murmur-manager/tree/master/interfaces/). However, if you want to do it manually, it’s not too hard.
+
+```ini
+glacierHost = "example.com"
+glacierPort = 1234
+user = "glacieruser"
+pass = "glacierpass"
+server_id = 1
+
+prx = ic.stringToProxy("Glacier2/router:tcp -h #{glacierHost} -p #{glacierPort}")
+router = ::Glacier2::RouterPrx::uncheckedCast(prx).ice_router(nil)
+router.createSession(user, pass)
+meta = Murmur::MetaPrx::checkedCast(ic.stringToProxy("Meta:tcp -h #{host} -p #{port}")).ice_router(router)
+server = meta.getServer(server_id).ice_router(router)
+```
+
+For each object you get a proxy to (including the return from `Murmur::MetaPrx::getServer`), you need to add `#ice_router(router)`.
+
+{{< aside >}}
+This content released under [Creative Commons Attribution Share Alike](http://creativecommons.org/licenses/by-sa/2.5/) unless otherwise noted. This content is based on {{< wiki Ice />}}.
+{{< /aside >}}

--- a/hugo/content/documentation/mumble-server/scripting/ice/php/_index.md
+++ b/hugo/content/documentation/mumble-server/scripting/ice/php/_index.md
@@ -1,0 +1,41 @@
+---
+title: Mumble Server Ice Scripting with PHP
+date: 2019-10-27
+weight: -30
+---
+Setup documentation that you may want to check out prior to this article: [PHP Setup]({{< relref "setup" >}}), [Ice]({{< relref ".." >}})
+
+With IcePHP establishing the connection to the interface **differs** between the Ice versions 3.3 and prior and 3.4 and later.
+
+## Ice <= 3.3
+
+There's an example script using the '''Ice 3.3''' approach (defining the ice.slice directive in the PHP settings) included in the source; have a look at `/mumble/blob/1.2.4/scripts/icedemo.php`.
+
+The establishing, minimum code, is:
+
+```php
+Ice_loadProfile();
+// initialize ice connection
+global $ICE;
+$base = $ICE->stringToProxy('Meta:tcp -h 127.0.0.1 -p 6502');
+$meta = $base->ice_checkedCast("::Murmur::Meta");
+```
+
+## Ice >= 3.4
+
+First, you will have to **generate PHP code** from the slice definitions `.ice` file. With Ice >= 3.4 installed, use the `slice2php` executable to generate it.
+
+For your PHP code, you’ll have to have the Ice.php and other libs (scripts provided by zeroc) in your PHPs include path to include them.
+
+```php
+require_once 'Ice.php';
+require_once 'Murmur.php';
+$ICE = Ice_initialize();
+$meta = Murmur_MetaPrxHelper::checkedCast($ICE->stringToProxy('Meta:tcp -h 127.0.0.1 -p 6502'));
+```
+
+Where `Murmur.php` is the generated file.
+
+{{< aside >}}
+This content released under [Creative Commons Attribution Share Alike](http://creativecommons.org/licenses/by-sa/2.5/) unless otherwise noted. This content is based on {{< wiki Ice />}}.
+{{< /aside >}}

--- a/hugo/content/documentation/mumble-server/scripting/ice/php/setup.md
+++ b/hugo/content/documentation/mumble-server/scripting/ice/php/setup.md
@@ -1,0 +1,327 @@
+---
+title: Mumble Server Ice Scripting with PHP - Setup
+date: 2019-10-27
+weight: -10
+license: cc-by-sa 2.5
+basedon: https://wiki.mumble.info/wiki/Ice
+---
+Note: This documentation is quite old and may need some verification or updating.
+
+How to convert Murmur.ice to Murmur.php for Ice >= 3.4.0 : <http://doc.zeroc.com/display/Ice/slice2php+Command-Line+Options>
+
+## How to setup Ice 3.4 for PHP with Apache on Linux (general)
+
+If your Linux distribution offers a binary packet for Ice with PHP (usually the name contains Ice and php) you can skip everything but naming the Murmur.ice slice file in the php.ini (see below). If there is no prepared package you'll have to try to find binaries for your system or {{< wiki "Ice#Compiling_Ice" "compile" />}} Ice yourself and add the extension to PHP and tell PHP where to find the Murmur.ice file.
+
+To add the IcePHP extension to PHP, first check that the file IcePHP.so for linux is in your php extensions folder specified in your php.ini as
+
+```ini
+extension_dir = /usr/lib/php5/extensions
+```
+
+If it is not, get the corresponding files from [ZeroC's downloads page](http://www.zeroc.com/download.html).
+
+Then either in your php.ini file or in your `/etc/php.d` or `/etc/php5/conf.d` folder in `ice.ini`, add the line
+
+```ini
+extension=IcePHP.so
+```
+
+At least the Linux RPMs will do this automatically, so check that you're not doing it a second time.
+
+Second, you have to tell the PHP parser where to find the <abbr title="Specification Language Ice">slice</abbr> file.
+
+Add
+
+```ini
+ice.slice = /path/to/Murmur.ice
+```
+
+to your `php.ini` or other config file (e.g. `ice.ini`).
+
+### Troubleshooting
+
+If you encounter problems, check your Apache log.
+
+If it tells you the PHP extension was compiled on an older api, you have to compile the IcePHP.so from source.
+
+Download `Ice-3.4.2.tar.gz` from [ZeroCs downloads page](http://www.zeroc.com/download.html), untar, cd into PHP, as written in the `INSTALL` file export the `ICE_HOME` environment variable pointing to your Ice install dir. If you installed it with an RPM, type
+
+```bash
+export ICE_HOME=/usr
+```
+
+then `make`, and in the `lib` folder, there will be your `IcePHP.so` file.
+
+One common error is
+
+```text
+PHP Warning:  PHP Startup: skipping dictionary ::Murmur::UserInfoMap - unsupported key type in Unknown on line 0
+```
+
+This is caused because the `.ice` file is slightly incompatible with older versions of php-ice. Edit the `Murmur.ice` file and find the following lines
+
+```ice
+/** User information map.
+  * Older versions of ice-php can't handle enums as keys. If you are using one of these, replace 'UserInfo' with 'byte'.
+  */
+ ```
+
+and perform the substitution mentioned.
+
+## How to Setup Ice for PHP with Apache on Debian/Ubuntu ==
+
+**Note:** For PHP Ice, there are major differences between the Ice versions 3.3 and 3.4. In more detail: 3.3 uses `.ice` definition files while 3.4 uses generated PHP files.
+
+Thus, depending on the version you are installing, you will have to follow different configuration steps.
+
+At the moment (2012-05-06) the current Debian stable is `squeeze`, for which the official repositories provide Ice 3.3. For Ubuntu on the other hand, the current stable version 12.04 (LTS) provides Ice 3.4 in its repositories. So make sure you follow the matching instructions.
+
+### Short, expert version
+
+* If `php-zeroc-ice` version >= `3.4`: `apt-get install php-zeroc-ice`, then add `/usr/share/Ice-3.4.2/php/lib` to your PHPs include path.
+* If `php-zeroc-ice` version <= `3.3`: `apt-get install php-zeroc-ice`, then add the `ice.slice` parameter to with value `<pathto>/murmur.ice` to your PHPs configuration.
+
+### Setup
+
+For the following guide, a set up Apache2 and PHP environment, and a working install of Murmur is assumed.
+
+#### Step 1 - PHP Ice extension
+
+First we need to install the Ice library for PHP. Execute the following in a root shell:
+
+```bash
+apt-get update
+apt-get install php-zeroc-ice
+```
+
+#### Step 2 - PHP Setup
+
+Now we need to tell PHP to load the IcePHP extension.
+Open the file ''/etc/php5/apache2/php.ini'' for editing:
+
+```bash
+vim /etc/php5/apache2/php.ini
+```
+
+OR:
+
+```bash
+nano -w /etc/php5/apache2/php.ini
+```
+
+Paste the folowing in the dynamic extensions section of the file:
+
+```ini
+extension=IcePHP.so
+```
+
+#### Step 3 - Reload and Check
+
+Everything should be set up so let's restart the servers so they load the updated config files.
+
+Restart your Apache2 daemon:
+
+```bash
+/etc/init.d/apache2 restart
+```
+
+Make a file named `phpinfo.php` in your web root and paste the following:
+
+```php
+<?php phpinfo(); ?>
+```
+
+Open the page in your browser, you should be greeted with PHP's information page. Search the page for `Ice version` to verify that the `IcePHP` extension has loaded.
+
+If you don't see `IcePHP`’s version and config info on this page, verify that the file `IcePHP.so` exists in PHP’s `extension_dir` (this will also be in your PHP info page). Once you’re sure that the IcePHP extension has loaded, delete the `phpinfo.php` file for security reasons.
+
+Now we will take a look in the mumble-server log to see if Murmur's Ice interface is listening:
+
+```bash
+tail -n10 /var/log/mumble-server/mumble-server.log
+```
+
+If you find a line similar to the following everything is fine and you can now communicate to Murmur via its Ice interface.
+
+```text
+<W>2012-03-24 13:37:11.316 MurmurIce: Endpoint "tcp -h 127.0.0.1 -p 6502" running
+```
+
+#### Step 4 - Setting up Murmur to provide Ice interface
+
+Now open the file ''/etc/mumble-server.ini'' for editing:
+
+```bash
+vim /etc/mumble-server.ini
+```
+
+OR:
+
+```bash
+nano -w /etc/mumble-server.ini
+```
+
+Comment the following line to disable {{< wiki DBus />}}:
+
+```ini
+#dbus=system
+```
+
+Uncomment or paste the following line to enable the Ice interface:
+
+```ini
+ice="tcp -h 127.0.0.1 -p 6502"
+```
+
+Restart your Mumble server:
+
+```bash
+/etc/init.d/mumble-server restart
+```
+
+After restarting the daemon Murmur will now listen for Ice requests.
+
+Now you can install and use any of the PHP based [[3rd Party Applications]] compatible with IcePHP version 3.4.
+
+## How to setup Ice for PHP with XAMPP on Windows
+
+### Pre Setup
+
+Download and install the following packages:
+
+* XAMPP for Windows <http://www.apachefriends.org>
+* ZeroC Ice <https://zeroc.com/downloads/ice>
+
+Now configure and start XAMPP.
+
+### Create developer environment for Windows
+
+* Open System in Control Panel
+* On the Advanced tab, click Environment Variables
+* Add the Ice Path to `%PATH%`
+
+Select the name `PATH` on user variables and edit. If the name `PATH` does not exist, select new. Enter now the `PATH` to your Ice installation dir.
+
+For example: `%PROGRAMFILES(x86)%\ZeroC\Ice-3.4.0\bin;%PATH%`
+
+Now logout from Windows or restart. After reboot check if included Ice in our environment. Open the CMD and try
+
+```batch
+slice2php
+```
+
+The Output return the `slice2php` help.
+
+### Configure XAMPP/PHP
+
+Copy the File php_ice.dll from `<your path>\ZeroC\Ice-3.4.0\bin` to `<your_path>\xampplite\php\ext`
+
+Edit the `php.ini` in `<your_path>\xampplite\php` and add
+
+```ini
+extension=php_ice.dll
+ice.slice=<mumble_path>\Murmur.ice
+```
+
+Now start XAMPP and check the `phpinfo()`.
+
+## Using different ice.slice on same host
+
+Sometimes you run two servers of mumble on the same host and you cannot load two slices with different mumble versions on the same time.
+
+The solution is to use ICE profiles, that will require extra files and unfortunately modification of scripts that run the default profile.
+
+Description on Debian etch with apache2, PHP as fcgid and cli.
+
+### Creating profiles
+
+* Lets create profile directory (as root/superuser user), I have created mine at
+ `/etc/php5/ice/`
+* Then create directories per profile (it will make life easier later)
+ `/etc/php5/ice/murmur.1.1.x`
+ `/etc/php5/ice/murmur.1.2.x`
+* To each of the corresponding directory I have placed the `Murmur.ice` file provided with the installs. You will notice that later upgrades will just consist of copying new files (instead of renaming).
+* time to make profiles.ini file that ICE will use: `vi /etc/php5/ice/profiles.ini`
+* Insert there below code:
+
+```ini
+[Murmur11x]
+slice=/etc/php5/ice/murmur.1.1.x/Murmur.ice
+
+[Murmur12x]
+slice=/etc/php5/ice/murmur.1.2.x/Murmur.ice
+```
+
+This way you got two profiles, first (`Murmur11x`) is loading slice file for older murmur setups, and the other (`Murmurm12x`) loads newer slices. Below example of directory structure:
+
+```text
+/etc/php5/ice
+|-- murmur.1.1.x
+|   `-- Murmur.ice
+|-- murmur.1.2.x
+|   `-- Murmur.ice
+`-- profiles.ini
+```
+
+### `IcePHP.ini`
+
+* Now time to alter `/etc/php5/cgi/conf.d/IcePHP.ini`, so it will look like this
+
+```ini
+extension = IcePHP.so
+ice.profiles=/etc/php5/ice/profiles.ini
+```
+
+Notice that we are adding ice.profile setting, so that ice knows where to search for profiles.
+
+Default profile is named `__default__` and you better avoid to make it.
+
+I got no idea about setting up default ice.slice entry (experience told me to force editing php files anyway, read below)
+
+#### Changing PHP scripts
+
+Next alter the source code of the php scripts you use. It consists of just altering the one function that tells ICE to load profile. By default the function is ran without parameter, and it looks like:
+
+```php
+Ice_loadProfile();
+```
+
+Now we will tell that function to load specific profile that it was designed for. Below example modifications to load different profiles for given ice profile:
+for older mumble:
+
+```php
+Ice_loadProfile('Murmur11x'); // load profile for scripts that talk with murmur 1.1.x
+```
+
+or for new mumble:
+
+```php
+Ice_loadProfile('Murmur12x'); // load profile for scripts that talk with murmur 1.2.x
+```
+
+Notice that single quotes are required.
+
+### Checking out if it works
+
+Remember to restart apache (your configuration may require it)
+
+See php/apache error logs when something goes wrong.
+
+If you get error like `unknown operation getUsers invoked on proxy of type ::Murmur::Server` then it means you use old `Murmur.ice` file. This happens when you try to connect using `Murmur.ice` from version 1.1.x to Murmur server 1.2.x, which require `Murmur.ice` 1.2.x. Update `Murmur.ice` on web server and restart it and then it should work.
+
+### Further steps
+
+I suggest you do the same with `/etc/php5/cli/conf.d` file and scripts that you run from console (crontab).
+
+Altering `php.ini` `error_reporting` is advised to disable generating massive amount of warning messages:
+
+```ini
+error_reporting = E_ALL & ~E_NOTICE & ~E_WARNING
+```
+
+You can also set up config files for those profile - more info at <http://www.zeroc.com/doc/Ice-3.3.1/manual/IcePHP.29.3.html>
+
+{{< aside >}}
+This content released under [Creative Commons Attribution Share Alike](http://creativecommons.org/licenses/by-sa/2.5/) unless otherwise noted. This content is based on {{< wiki Ice />}}.
+{{< /aside >}}

--- a/hugo/content/documentation/mumble-server/scripting/ice/server-setup.md
+++ b/hugo/content/documentation/mumble-server/scripting/ice/server-setup.md
@@ -1,0 +1,42 @@
+---
+title: Mumble Server Configuration to Enable Ice
+date: 2019-10-27
+weight: -100
+---
+To enable the Ice interface in your `murmur.ini` configuration file, we recommend to first disable DBus by commenting out:
+
+```ini
+dbus=session
+```
+
+Then enable Ice for ''localhost'' on port ''6502'' by adding or uncommenting:
+
+```ini
+ice="tcp -h 127.0.0.1 -p 6502"
+```
+
+Now restart Murmur so the change takes effect.
+
+To check if Ice in fact does listen, on UNIX type:
+
+```bash
+netstat -apn | grep 6502
+```
+
+and on Windows type:
+
+```batch
+netstat -an
+```
+
+and look for the process listening on port `6502`.
+
+If the port is not being listened on, check Murmurs log. It should state enabling ice on startup. If it does not, something of your configuration went wrong.
+
+```text
+MurmurIce: Endpoint "tcp -h 127.0.0.1 -p 6502" running
+```
+
+{{< aside >}}
+This content released under [Creative Commons Attribution Share Alike](http://creativecommons.org/licenses/by-sa/2.5/) unless otherwise noted. This content is based on {{< wiki Ice />}}.
+{{< /aside >}}


### PR DESCRIPTION
* Add a landing page for documentation
* Add a scripting page
* Migrate Ice wiki documentation
  * Split into subpages
  * Adjust formatting to markdown
  * Drop very obsolete block (also removed from wiki)
  * Fix various errors, various improvements
  * More consistent and throughout use of markup

This change migrates the Ice documentation. It does not yet improve the layout for documentation, but will allow us to do so with some content and subpages.

For now an aside license and wiki link footer is added. This can probably be improved in the future by adding front matter and rendering it in the layout.