### PR TITLE
Content: Improve sponsors page layout

### DIFF
--- a/hugo/content/sponsors.md
+++ b/hugo/content/sponsors.md
@@ -6,9 +6,9 @@ Our infrastructure is made possible thanks to the help of the sponsors that supp
 
 ## Fastly
 
-<img src="/logos/fastly.svg" alt="Fastly's logo" style="float:right; width: 380px; max-width: 40vw; margin: 12px 0 12px 24px;">
+<img src="/logos/fastly.svg" alt="Fastly’s logo" style="float:right; width: 380px; max-width: 40vw; margin: 12px 0 12px 24px;">
 
-Thanks to [Fastly](https://www.fastly.com)'s CDN, only ~5% of the traffic hits our servers. The rest of the traffic is served by their insanely fast network.
+Thanks to [Fastly](https://www.fastly.com)’s CDN, only ~5% of the traffic hits our servers. The rest of the traffic is served by their insanely fast network.
 
 This service provides us quite a few important advantages, such as:
 
@@ -18,14 +18,14 @@ This service provides us quite a few important advantages, such as:
 * IPv6 support, even for IPv4-only backends.
 * DDoS protection.
 
-Also, we haven't experienced a single downtime in many years.
+Also, we haven’t experienced a single downtime in many years.
 
 ## MacStadium
 
-<img src="/logos/macstadium.svg" alt="MacStadium's logo" style="float:right; width: 380px; max-width: 40vw; margin: 12px 0 12px 24px;">
+<img src="/logos/macstadium.svg" alt="MacStadium’s logo" style="float:right; width: 380px; max-width: 40vw; margin: 12px 0 12px 24px;">
 
 Thanks to [MacStadium](https://www.macstadium.com) we can maintain support for macOS, as they provide us access to a 2012 Mac Mini.
 
 Before that, the only member of our team who owns a Mac used to do all the macOS-related work, until he unfortunately had no time to dedicate to the project anymore.
 
-We're very happy with the service so far. *Slightly* less happy with macOS, but that's another story (and unrelated to the service itself).
+We’re very happy with the service so far. *Slightly* less happy with macOS, but that’s another story (and unrelated to the service itself).

--- a/hugo/content/sponsors.md
+++ b/hugo/content/sponsors.md
@@ -6,7 +6,7 @@ Our infrastructure is made possible thanks to the help of the sponsors that supp
 
 ## Fastly
 
-![Fastly's logo](/logos/fastly.svg)
+<img src="/logos/fastly.svg" alt="Fastly's logo" style="float:right; width: 380px; max-width: 40vw; margin: 12px 0 12px 24px;">
 
 Thanks to [Fastly](https://www.fastly.com)'s CDN, only ~5% of the traffic hits our servers. The rest of the traffic is served by their insanely fast network.
 
@@ -22,7 +22,7 @@ Also, we haven't experienced a single downtime in many years.
 
 ## MacStadium
 
-![MacStadium's logo](/logos/macstadium.svg)
+<img src="/logos/macstadium.svg" alt="MacStadium's logo" style="float:right; width: 380px; max-width: 40vw; margin: 12px 0 12px 24px;">
 
 Thanks to [MacStadium](https://www.macstadium.com) we can maintain support for macOS, as they provide us access to a 2012 Mac Mini.
 

--- a/hugo/content/sponsors.md
+++ b/hugo/content/sponsors.md
@@ -4,7 +4,7 @@ title: Sponsors
 
 Our infrastructure is made possible thanks to the help of the sponsors that supported us over the years by providing their services for free.
 
-# Fastly
+## Fastly
 
 ![Fastly's logo](/logos/fastly.svg)
 
@@ -20,7 +20,7 @@ This service provides us quite a few important advantages, such as:
 
 Also, we haven't experienced a single downtime in many years.
 
-# MacStadium
+## MacStadium
 
 ![MacStadium's logo](/logos/macstadium.svg)
 


### PR DESCRIPTION
Improvements to the Sponsors page layout.

I think the logos are way too big, jumping into one’s face, diminishing clarity of the text and content.

This PR includes two technically unrelated changes to the same content: Using typographically correct apostrophes and fixing the heading levels.

|  | Before | After this change |
|---|---|---|
| full width | ![image](https://user-images.githubusercontent.com/93181/94860029-c3d18c80-0435-11eb-8ed2-958786436379.png) | ![image](https://user-images.githubusercontent.com/93181/94860063-cfbd4e80-0435-11eb-910b-b8a4121e5b56.png) |
| small width | ![image](https://user-images.githubusercontent.com/93181/94860134-e663a580-0435-11eb-93a0-b26fa991416d.png) | ![image](https://user-images.githubusercontent.com/93181/94860154-eebbe080-0435-11eb-9e23-c305ff8c630d.png) |
