### PR TITLE
Add heading hover-id-links

### DIFF
--- a/hugo/assets/css/common.scss
+++ b/hugo/assets/css/common.scss
@@ -44,17 +44,6 @@ ul.menu {
 	b, strong {
 		font-weight: bold;
 	}
-	h1, h2, h3, h4, h5, h6 {
-		position: relative;
-	}
-	
-	.headlineanchor { font-size: 0.9em; visibility: hidden; padding-left: 4px; position: absolute; top: 0; display: inline-block; }
-
-	h1:hover, h2:hover, h3:hover, h4:hover, h5:hover, h6:hover {
-		.headlineanchor {
-			visibility: visible;
-		}
-	}
 }
 
 figure {

--- a/hugo/assets/css/layout.scss
+++ b/hugo/assets/css/layout.scss
@@ -90,3 +90,24 @@ nav.blogposts {
 		text-align: right;
 	}
 }
+h1, h2, h3, h4, h5, h6 {
+	position: relative;
+
+	.heading-link {
+		display: none;
+		width: 21px;
+		position: absolute;
+		top: 6px;
+		left: -21px;
+		opacity: 0.7;
+		font-size: 12px;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	&:hover .heading-link {
+		display: block;
+	}
+}

--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -22,5 +22,16 @@
     </div>
 
     {{ partial "layout/footer.html" . }}
+    <script>
+        let headings = document.querySelectorAll('h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]')
+        for (let i = 0; i < headings.length; ++i) {
+            let heading = headings[i]
+            let anchor = document.createElement('a')
+            anchor.href = '#' + heading.id
+            anchor.className = 'heading-link'
+            anchor.innerText = '🔗'
+            heading.prepend(anchor)
+        }
+    </script>
 </body>
 </html>

--- a/hugo/layouts/blog/single.html
+++ b/hugo/layouts/blog/single.html
@@ -17,9 +17,7 @@
     {{- partial "toc.html" . -}}
     <p>Posted on {{ .Date.Format "January 1, 2006" }}{{ with .Params.author }} by {{ . }}{{ end }}</p>
 
-    {{- with .Content -}}
-        {{ . | replaceRE "(<h[1-9] id=\"([^\"]+)\".+)(</h[1-9]+>)" `${1}<a href="#${2}" class="headlineanchor" aria-label="Anchor Link">🔗&#xFE0E;</a>${3}` | safeHTML }}
-    {{- end -}}
+    {{ .Content }}
 </div>
 
 {{ end }}


### PR DESCRIPTION
For headings with an id attribute add anchors that show on hover and are clickable.
They link to the #id hash so clicking them will jump to that headline and update the address bar,
and copying their link will copy a link to that page and heading.

![screenshot of hover anchor](https://user-images.githubusercontent.com/93181/97782686-41063380-1b93-11eb-8e9d-dce921a44e0c.png)

The anchor will show on hover anywhere on the heading (not just to the left of it where the anchor link is).

This also does not break our 1.3.0 release notes blog post which had anchors at the end of them.

![screenshot of double-anchors in 1.3.0 blog post](https://user-images.githubusercontent.com/93181/97782646-06040000-1b93-11eb-867d-95a907ab8c23.png)

The unicode link character could be replaced with an icon. A blue color to match our hyperlinks could be good. We could also change that later though.

This change is especially useful for longer blog posts like release announcements, and will be useful for longer content pages, especially documentation.

Implements #43.