### PR TITLE
Config: Update URL paths in menus.toml

### DIFF
--- a/hugo/config/_default/menus.toml
+++ b/hugo/config/_default/menus.toml
@@ -8,40 +8,40 @@
     title = "Downloads"
     weight = 2
     identifier = "downloads"
-    url = "/downloads"
+    url = "/downloads/"
 
 [[main]]
     title = "Documentation"
     weight = 3
     identifier = "docs"
-    url = "/documentation"
+    url = "/documentation/"
 
 [[main]]
     title = "Blog"
     weight = 4
     identifier = "blog"
-    url = "/blog"
+    url = "/blog/"
 
 [[main]]
     title = "Contribute"
     weight = 5
     identifier = "contribute"
-    url = "/contribute"
+    url = "/contribute/"
 
 [[main]]
     title = "Sponsors"
     weight = 6
     identifier = "sponsors"
-    url = "/sponsors"
+    url = "/sponsors/"
 
 [[footer]]
     title = "Security"
     weight = 1
     identifier = "security"
-    url = "/security"
+    url = "/security/"
 
 [[footer]]
     title = "Privacy"
     weight = 2
     identifier = "privacy"
-    url = "/privacy"
+    url = "/privacy/"


### PR DESCRIPTION
The current header links seem to point to a directory or have additional webserver config which causes the server to issue a redirect to the actual page. This introduces an extra RTT of latency for the page load which could be removed by having the links point directly.

Example of the current behavior:
```
$ curl -i https://www.mumble.info/downloads
HTTP/2 301
server: Apache
location: downloads/
accept-ranges: bytes
date: Mon, 01 Feb 2021 20:43:38 GMT
via: 1.1 varnish
age: 368
x-served-by: cache-ewr18153-EWR
x-cache: HIT
x-cache-hits: 1
x-timer: S1612212219.622961,VS0,VE0
strict-transport-security: max-age=300
content-length: 0
```