### PR TITLE
DOWNLOADS: Added HFS+ package for older macOS

### DIFF
--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -52,7 +52,7 @@ function getPlatformContent(platform) {
         case 'linux':
             return getButton('ubuntu', 'ubuntu.svg', 'Mumble PPA for Ubuntu')
         case 'macos':
-            return getButton('osx', 'apple.svg', 'Mumble for macOS')
+            return getButton('osx', 'apple.svg', 'Mumble for macOS >= 10.13')
         default:
             return 'We could not determine the OS you are browsing this website on. Please choose the appropriate download yourself.'
             break;
@@ -69,12 +69,16 @@ document.getElementById('suggested-download').innerHTML = getPlatformContent(get
 {{< /content-layout/downloads >}}
 
 {{< content-layout/downloads >}}
-{{< content-layout/download name="macOS" href="osx" osclass="mac">}}
-{{< content-layout/download name="Static macOS Server" href="osx-static-server" osclass="mac">}}
+{{< content-layout/download name="macOS >= 10.13" href="osx" osclass="mac">}}
+{{< content-layout/download name="macOS <= 10.12" href="osx-hfs+" osclass="mac">}}
 {{< /content-layout/downloads >}}
 
 {{< content-layout/downloads >}}
 {{< content-layout/download name="Ubuntu" href="ubuntu" osclass="ubuntu">}}
+{{< /content-layout/downloads >}}
+
+{{< content-layout/downloads >}}
+{{< content-layout/download name="Static macOS Server" href="osx-static-server" osclass="mac">}}
 {{< content-layout/download name="Static Linux Server" href="linux-static-server" osclass="linux">}}
 {{< /content-layout/downloads >}}
 

--- a/src/downloads.go
+++ b/src/downloads.go
@@ -10,6 +10,7 @@ func setupDownloadsStable(mux *http.ServeMux) {
 		"windows-32":          "https://github.com/mumble-voip/mumble/releases/download/1.3.4/mumble-1.3.4.msi",
 		"windows-64":          "https://github.com/mumble-voip/mumble/releases/download/1.3.4/mumble-1.3.4.winx64.msi",
 		"osx":                 "https://github.com/mumble-voip/mumble/releases/download/1.3.3/Mumble-1.3.3.dmg",
+		"osx-hfs+":            "https://github.com/mumble-voip/mumble/releases/download/1.3.3/Mumble-1.3.3-HFS+.dmg",
 		"ios":                 "http://itunes.apple.com/us/app/mumble/id443472808?ls=1&mt=8",
 		"ubuntu":              "https://launchpad.net/~mumble/+archive/release",
 		"linux-static-server": "https://github.com/mumble-voip/mumble/releases/download/1.3.4/murmur-static_x86-1.3.4.tar.bz2",


### PR DESCRIPTION
macOS <= 10.12 apparently does not support the new APFS filesystem that
we are using to package the dmg binary. Therefore we are now also
providing a version using the older HFS+ filesystem.

See https://github.com/mumble-voip/mumble/issues/4655