### PR TITLE
Downloads: Handle undefined navigator attributes

### DIFF
--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -17,6 +17,8 @@ JavaScript. However JavaScript seems to not be enabled. Please refer to the manu
 'use strict'
 /* For win always Win32 on Firefox and Chrome */
 function parsePlatform(value) {
+    if (!value)
+        return false;
     value = value.toLowerCase()
     if (value.includes('Windows NT')) {
         if (value.includes('win64') || value.includes('wow64')) {


### PR DESCRIPTION
The script to determine the user's OS throws an exception in some browsers as `navigator.oscpu` is not necessarily set.

```
(index):69 Uncaught TypeError: Cannot read property 'toLowerCase' of undefined
    at parsePlatform ((index):69)
    at getPlatform ((index):90)
    at (index):110
```

This PR adds a check to avoid trying to perform string operations on undefined values.