### PR TITLE
Downloads: Fix case sensitivity in platform names

### DIFF
--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -20,7 +20,7 @@ function parsePlatform(value) {
     if (!value)
         return false;
     value = value.toLowerCase()
-    if (value.includes('Windows NT')) {
+    if (value.includes('windows nt')) {
         if (value.includes('win64') || value.includes('wow64')) {
             return 'win64'
         }
@@ -29,7 +29,7 @@ function parsePlatform(value) {
     if (value.includes('windows')) {
         return 'win64'
     }
-    if (value.includes('Mac OS X') || value.includes('macOS')) {
+    if (value.includes('mac os x') || value.includes('macos')) {
         return 'macos'
     }
     if (value.includes('android')) {


### PR DESCRIPTION
As the value is lowercased by `toLowerCase()`, comparing the platform strings with a mixed case string doesn't work as intended. This causes macOS users to not be correctly identified. Not sure how I missed this in my previous PR!