### PR TITLE
Use generated Table of Contents on Contribute page

### DIFF
--- a/hugo/content/contribute.md
+++ b/hugo/content/contribute.md
@@ -1,26 +1,10 @@
 ---
 title: Contribute
-toc: true
 ---
 
 You can contribute to the Mumble Project in multiple ways:
 
-<!-- Table of Content -->
-
-- [Report Bugs and suggest Improvements/Features](#report-bugs-and-feature-requests)
-- [Help with Development](#development)
-  - [Coding](#coding)
-    - [Additional projects](#additional-projects)
-  - Non-Coding:
-    - [Translation](#translation)
-    - [Testing](#testing)
-    - [GUI/Mumble Themes](#mumble-theme)
-- Improve the [Documentation](#documentation) and [Website](#website)
-- [Support other users & take part in our community](#community)
-- [Host a Mumble server](#hosting)
-- [Promote Mumble](#promotion)
-
----
+{{< toc >}}
 
 ## Report bugs and Feature Requests
 

--- a/hugo/layouts/shortcodes/toc.html
+++ b/hugo/layouts/shortcodes/toc.html
@@ -1,0 +1,1 @@
+{{.Page.TableOfContents}}


### PR DESCRIPTION
The manually added ToC targets anchors. As a result when updating headlines the ToC must also be updated.
This is error prone.

The resulting ToC list changes slightly in which headlines it displays.
Instead of a selection over three levels deep, the first two headline levels are listed.
This works fine for the content at hand.

---

Screenshot of the ToC before and after:

![image](https://user-images.githubusercontent.com/93181/111865707-d64e6c80-8968-11eb-94bd-d31ef6979267.png)
