### PR TITLE
Home: Show latest news and release post

### DIFF
--- a/hugo/assets/css/home.scss
+++ b/hugo/assets/css/home.scss
@@ -32,3 +32,13 @@
 		}
 	}
 }
+
+#home-newsblock {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-gap: 2em;
+
+	@media (max-width: 600px) {
+		grid-template-columns: 1fr;
+	}
+}

--- a/hugo/content/blog/2010-08-17-for-the-record.md
+++ b/hugo/content/blog/2010-08-17-for-the-record.md
@@ -3,7 +3,6 @@ title: For the record
 author: .D0T
 date: 2010-08-17T21:20:17+00:00
 categories:
-  - News
   - Tech talk
 tags:
   - feature

--- a/hugo/content/blog/2010-12-05-mumble-1-2-3-rc-released.md
+++ b/hugo/content/blog/2010-12-05-mumble-1-2-3-rc-released.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.3 RC released
 author: .D0T
 date: 2010-12-05T01:22:30+00:00
 categories:
-  - News
   - Release
 tags:
   - Bugs

--- a/hugo/content/blog/2011-01-23-mumble-1-2-3-rc2-released.md
+++ b/hugo/content/blog/2011-01-23-mumble-1-2-3-rc2-released.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.3 RC2 released
 author: .D0T
 date: 2011-01-23T04:38:44+00:00
 categories:
-  - News
   - Release
 tags:
   - rc

--- a/hugo/content/blog/2012-02-12-mumble-for-ios-1-0.md
+++ b/hugo/content/blog/2012-02-12-mumble-for-ios-1-0.md
@@ -3,7 +3,6 @@ title: Mumble for iOS 1.0
 author: mkrautz
 date: 2012-02-12T20:41:27+00:00
 categories:
-  - News
   - Release
 
 ---

--- a/hugo/content/blog/2012-04-26-mumble-for-ios-1-1.md
+++ b/hugo/content/blog/2012-04-26-mumble-for-ios-1-1.md
@@ -7,7 +7,6 @@ excerpt: |
 
   This release addresses quite a few of the most sought-after features missing from the 1.0 version, along with fixes for various crashes and memory leaks.
 categories:
-  - News
   - Release
 tags:
   - ios

--- a/hugo/content/blog/2012-09-20-mumble-for-ios-1-1-1.md
+++ b/hugo/content/blog/2012-09-20-mumble-for-ios-1-1-1.md
@@ -3,7 +3,6 @@ title: Mumble for iOS 1.1.1
 author: mkrautz
 date: 2012-09-20T22:20:52+00:00
 categories:
-  - News
   - Release
 tags:
   - ios

--- a/hugo/content/blog/2013-06-01-mumble-1-2-4-released.md
+++ b/hugo/content/blog/2013-06-01-mumble-1-2-4-released.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.4 released
 author: .D0T
 date: 2013-06-01T22:13:27+00:00
 categories:
-  - News
   - Release
 
 ---

--- a/hugo/content/blog/2013-06-11-mumble-for-ios-1-2.md
+++ b/hugo/content/blog/2013-06-11-mumble-for-ios-1-2.md
@@ -3,7 +3,6 @@ title: Mumble for iOS 1.2
 author: mkrautz
 date: 2013-06-11T22:03:56+00:00
 categories:
-  - News
   - Release
 tags:
   - ios

--- a/hugo/content/blog/2013-06-20-mumble-for-ios-1-2-1.md
+++ b/hugo/content/blog/2013-06-20-mumble-for-ios-1-2-1.md
@@ -3,7 +3,6 @@ title: Mumble for iOS 1.2.1
 author: mkrautz
 date: 2013-06-20T21:57:41+00:00
 categories:
-  - News
   - Release
 tags:
   - ios

--- a/hugo/content/blog/2013-09-20-mumble-for-ios-1-2-2.md
+++ b/hugo/content/blog/2013-09-20-mumble-for-ios-1-2-2.md
@@ -3,7 +3,6 @@ title: Mumble for iOS 1.2.2
 author: mkrautz
 date: 2013-09-20T10:23:32+00:00
 categories:
-  - News
   - Release
 tags:
   - ios

--- a/hugo/content/blog/2014-02-05-mumble-1-2-5.md
+++ b/hugo/content/blog/2014-02-05-mumble-1-2-5.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.5
 author: mkrautz
 date: 2014-02-05T15:00:13+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2014-02-05-mumble-for-ios-1-2-3.md
+++ b/hugo/content/blog/2014-02-05-mumble-for-ios-1-2-3.md
@@ -3,7 +3,6 @@ title: Mumble for iOS 1.2.3
 author: mkrautz
 date: 2014-02-05T15:00:12+00:00
 categories:
-  - News
   - Release
   - Security
 tags:

--- a/hugo/content/blog/2014-03-12-mumble-for-ios-1-3-0.md
+++ b/hugo/content/blog/2014-03-12-mumble-for-ios-1-3-0.md
@@ -3,7 +3,6 @@ title: Mumble for iOS 1.3.0
 author: mkrautz
 date: 2014-03-12T23:47:24+00:00
 categories:
-  - News
   - Release
 tags:
   - ios

--- a/hugo/content/blog/2014-05-14-mumble-1-2-6.md
+++ b/hugo/content/blog/2014-05-14-mumble-1-2-6.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.6
 author: mkrautz
 date: 2014-05-14T23:50:39+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2014-08-08-mumble-1-2-8.md
+++ b/hugo/content/blog/2014-08-08-mumble-1-2-8.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.8
 author: mkrautz
 date: 2014-08-08T23:38:26+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2015-06-11-mumble-1-2-9.md
+++ b/hugo/content/blog/2015-06-11-mumble-1-2-9.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.9
 author: mkrautz
 date: 2015-06-11T18:46:27+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2015-07-10-mumble-1-2-10.md
+++ b/hugo/content/blog/2015-07-10-mumble-1-2-10.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.10
 author: mkrautz
 date: 2015-07-10T12:01:11+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2015-12-06-mumble-1-2-11.md
+++ b/hugo/content/blog/2015-12-06-mumble-1-2-11.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.11
 author: mkrautz
 date: 2015-12-06T10:34:21+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2015-12-20-mumble-1-2-12.md
+++ b/hugo/content/blog/2015-12-20-mumble-1-2-12.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.12
 author: mkrautz
 date: 2015-12-20T18:56:01+00:00
 categories:
-  - News
   - Release
 
 ---

--- a/hugo/content/blog/2016-01-10-mumble-1-2-13.md
+++ b/hugo/content/blog/2016-01-10-mumble-1-2-13.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.13
 author: mkrautz
 date: 2016-01-10T13:01:11+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2016-03-01-mumble-1-2-14.md
+++ b/hugo/content/blog/2016-03-01-mumble-1-2-14.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.14
 author: mkrautz
 date: 2016-03-01T05:57:28+00:00
 categories:
-  - News
   - Release
 
 ---

--- a/hugo/content/blog/2016-03-05-mumble-1-2-15.md
+++ b/hugo/content/blog/2016-03-05-mumble-1-2-15.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.15
 author: mkrautz
 date: 2016-03-05T16:45:30+00:00
 categories:
-  - News
   - Release
 
 ---

--- a/hugo/content/blog/2016-05-05-mumble-1-2-16.md
+++ b/hugo/content/blog/2016-05-05-mumble-1-2-16.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.16
 author: mkrautz
 date: 2016-05-05T22:50:36+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2016-09-24-mumble-1-2-17.md
+++ b/hugo/content/blog/2016-09-24-mumble-1-2-17.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.17
 author: mkrautz
 date: 2016-09-24T21:36:28+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2017-01-27-mumble-1-2-19.md
+++ b/hugo/content/blog/2017-01-27-mumble-1-2-19.md
@@ -3,7 +3,6 @@ title: Mumble 1.2.19
 author: mkrautz
 date: 2017-01-27T15:00:23+00:00
 categories:
-  - News
   - Release
   - Security
 

--- a/hugo/content/blog/2020-06-08-mumble-1-3-1-release.md
+++ b/hugo/content/blog/2020-06-08-mumble-1-3-1-release.md
@@ -3,7 +3,6 @@ title: Mumble 1.3.1 Release Announcement
 author: Jan Klass
 date: 2020-06-08
 categories:
-  - News
   - Release
   - Security
 ---

--- a/hugo/content/blog/2020-07-09-mumble-1-3-2-release.md
+++ b/hugo/content/blog/2020-07-09-mumble-1-3-2-release.md
@@ -3,7 +3,6 @@ title: Mumble 1.3.2 Release Announcement
 author: Robert Adam
 date: 2020-07-09
 categories:
-  - News
   - Release
 ---
 The Mumble team has released [**version 1.3.2**](https://github.com/mumble-voip/mumble/releases/tag/1.3.2) of the Mumble VoIP application. This is a

--- a/hugo/content/blog/2020-10-05-mumble-1-3-3-release.md
+++ b/hugo/content/blog/2020-10-05-mumble-1-3-3-release.md
@@ -3,7 +3,6 @@ title: Mumble 1.3.3 Release Announcement
 author: Robert Adam
 date: 2020-10-05
 categories:
-  - News
   - Release
   - Security
 ---

--- a/hugo/content/blog/2020-12-24-mumble-1-4-0-snapshot.md
+++ b/hugo/content/blog/2020-12-24-mumble-1-4-0-snapshot.md
@@ -3,7 +3,6 @@ title: First Mumble 1.4.0 Development Snapshot
 author: Robert Adam
 date: 2020-12-24
 categories:
-  - News
   - Release
   - Development Snapshot
 ---

--- a/hugo/content/blog/2021-02-10-mumble-1-3-4-release.md
+++ b/hugo/content/blog/2021-02-10-mumble-1-3-4-release.md
@@ -3,7 +3,6 @@ title: Mumble 1.3.4 Release Announcement
 author: Robert Adam
 date: 2021-01-10
 categories:
-  - News
   - Release
   - Security
 ---

--- a/hugo/content/blog/2021-02-26-mumble-1-4-0-snapshot2.md
+++ b/hugo/content/blog/2021-02-26-mumble-1-4-0-snapshot2.md
@@ -3,7 +3,6 @@ title: 1.4.0 Development Snapshot 2
 author: Robert Adam
 date: 2021-02-26
 categories:
-  - News
   - Release
   - Development Snapshot
 ---

--- a/hugo/content/blog/2021-03-21-mumble-1-4-0-snapshot3.md
+++ b/hugo/content/blog/2021-03-21-mumble-1-4-0-snapshot3.md
@@ -3,7 +3,6 @@ title: 1.4.0 Development Snapshot 3
 author: Robert Adam
 date: 2021-03-21
 categories:
-  - News
   - Release
   - Development Snapshot
 ---

--- a/hugo/content/blog/2021-04-03-mumble-1-4-0-snapshot4.md
+++ b/hugo/content/blog/2021-04-03-mumble-1-4-0-snapshot4.md
@@ -3,7 +3,6 @@ title: 1.4.0 Development Snapshot 4
 author: Robert Adam
 date: 2021-04-03
 categories:
-  - News
   - Release
   - Development Snapshot
 ---

--- a/hugo/content/blog/2021-04-21-mumble-1-4-0-snapshot5.md
+++ b/hugo/content/blog/2021-04-21-mumble-1-4-0-snapshot5.md
@@ -3,7 +3,6 @@ title: 1.4.0 Development Snapshot 5
 author: Robert Adam
 date: 2021-04-21
 categories:
-  - News
   - Release
   - Development Snapshot
 ---

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -3,20 +3,34 @@
 	<p>Welcome to <b>official website of the Mumble project!</b></p>
 	<p><a class="download-button" href="{{ relref . "downloads" }}">Download now</a></p>
 
-	<h2>Latest News</h2>
-	<div>
-		{{ $blog := .Site.GetPage "blog" }}
-		{{ $pages := $blog.Pages }}
-		{{ $news := where $pages ".Params.categories" "intersect" (slice "News") }}
-		{{ $page := first 1 $news }}
-		{{ range $page }}
-			<div class="markdown-body">
-				<h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
-				{{ partial "blog/teaser" . }}
+	{{ $blogpages := (.Site.GetPage "blog").Pages }}
+	{{ $news := where $blogpages ".Params.categories" "intersect" (slice "News") }}
+	{{ $releases := where $blogpages ".Params.categories" "intersect" (slice "Release") }}
+	<div id="home-newsblock">
+		<div>
+			<h2>Latest News</h2>
+			<div>
+				{{ $latestNews := first 1 $news }}
+				{{ range $latestNews }}
+					<div class="markdown-body">
+						<h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+						{{ partial "blog/teaser" . }}
+					</div>
+				{{ end }}
 			</div>
-		{{ else }}
-			<p>No news has been published yet.</p>
-		{{ end }}
+		</div>
+		<div>
+			<h2>Latest Release</h2>
+			<div>
+				{{ $latestRelease := first 1 ($releases) }}
+				{{ range $latestRelease }}
+					<div class="markdown-body">
+						<h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+						{{ partial "blog/teaser" . }}
+					</div>
+				{{ end }}
+			</div>
+		</div>
 	</div>
 
 	<h2>About Mumble</h2>


### PR DESCRIPTION
Both have validity and are important, a post may be published in both categories in close time.
We want to promote both kinds.

Latest release remains valid and interesting to users landing on home.
Latest news is also a good entry and nudge that we have them even if older.

![image](https://user-images.githubusercontent.com/93181/118197629-a050d480-b44f-11eb-8b33-e856d00b79d4.png)
![image](https://user-images.githubusercontent.com/93181/118197676-b2cb0e00-b44f-11eb-936d-7daeae7970e7.png)
