### PR TITLE
Add matrix.to link to contact page

### DIFF
--- a/hugo/content/contact.md
+++ b/hugo/content/contact.md
@@ -8,7 +8,7 @@ You can contact us in several ways.
 
 * [Issue tracker on GitHub](https://github.com/mumble-voip/mumble/issues)
 * [Discussions on GitHub](https://github.com/mumble-voip/mumble/discussions)
-* Chat `#mumble:matrix.org`  
+* Chat [`#mumble:matrix.org`](https://matrix.to/#/#mumble:matrix.org)  
   usable with any Matrix chat client; for example [open with Element](https://app.element.io/#/room/#mumble:matrix.org)  
 * [Forum](https://forums.mumble.info/)
 


### PR DESCRIPTION
This will make it easy for people to join the chat using their preferred Matrix application.

Matrix apps may even bind an handler to the URL on some platforms. I think Element Android does that, so clicking this link will open the chat up in their app of choice.