### PR TITLE
Remove remaining references to IRC

### DIFF
--- a/hugo/content/contribute.md
+++ b/hugo/content/contribute.md
@@ -25,7 +25,7 @@ Thus previous knowledge in C++ and Qt is definitely useful, but we also encourag
 
 #### Getting Started
 
-The best way to get into Mumble development is to link up with us on IRC ([#mumble-dev on freenode](irc://chat.freenode.net/mumble-dev)), also available via Matrix (Join: `#freenode_#mumble-dev:matrix.org` or use the [Direct Link via Element.io (Web App)](https://app.element.io/#/room/!VNUpYnUPdhTAqagvUu:matrix.org)).
+The best way to get into Mumble development is to link up with us on [Matrix](https://matrix.org/). Join [`#mumble-dev:matrix.org`](https://matrix.to/#/#mumble-dev:matrix.org) or use the [Direct Link via Element.io (Web App)](https://app.element.io/#/room/!VNUpYnUPdhTAqagvUu:matrix.org).
 
 Alternatively you can create or comment (on) a pull request or issue report on GitHub.
 

--- a/hugo/content/documentation/developer/positional-audio/create-plugin/_index.md
+++ b/hugo/content/documentation/developer/positional-audio/create-plugin/_index.md
@@ -7,7 +7,7 @@ This is an abstract overview of how to add positional audio support; for step-by
 
 For positional audio, we need two things: Your position in the 3D world, and the direction you are looking in. If you have access to the source code for the game, exporting this to Mumble is easy, just use the Link plugin. If this is a 3rd party game, we'll have to extract the position from the running game.
 
-If you have any questions regarding the process hit us in IRC (#mumble @ freenode) and we will try to help.
+If you have any questions regarding the process hit us up in [`#mumble-dev:matrix.org`](https://matrix.to/#/#mumble-dev:matrix.org) and we will try to help.
 
 We also accept new plugins into our codebase as long as you are willing to support them. Be aware however that we might reject plugins for games with short update cycles as our current distribution method makes keeping those working for longer times quite painful. When in doubt please verify with us before puttin in the work.
 

--- a/hugo/content/documentation/developer/positional-audio/create-plugin/guide/index.md
+++ b/hugo/content/documentation/developer/positional-audio/create-plugin/guide/index.md
@@ -5,7 +5,7 @@ Warning: Be aware that the tools/methods used in this tutorial might trigger ant
 
 Game positional audio is a feature of Mumble that many users consider very useful. However, creating the game plugin can sometimes be complicated, and for the average person, daunting. This guide will help you understand how a game plugin works, what it does, and how you can make one.
 
-If you have any questions regarding the process hit us in IRC (#mumble @ freenode) and we will try to help.
+If you have any questions regarding the process hit us up in [`#mumble-dev:matrix.org`](https://matrix.to/#/#mumble-dev:matrix.org) and we will try to help.
 
 We also accept new plugins into our codebase as long as you are willing to support them. Be aware however that we might reject plugins for games with short update cycles as our current distribution method makes keeping those working for longer times quite painful. When in doubt please verify with us before puttin in the work.
 


### PR DESCRIPTION
As discussed in https://github.com/mumble-voip/mumble/discussions/5041 IRC is deprecated in favor of Matrix.