### PR TITLE
Release RC1 of Mumble 1.4.0

### DIFF
--- a/hugo/content/blog/2021-09-12-mumble-release-candidate1.md
+++ b/hugo/content/blog/2021-09-12-mumble-release-candidate1.md
@@ -1,0 +1,65 @@
+---
+title: 1.4.0 Release Candidate 1
+author: Robert Adam
+date: 2021-09-12
+categories:
+  - Release
+  - Release Candidate
+---
+
+Quite some time has passed since our [last snapshot]({{< relref ""2021-05-16-mumble-1-4-0-snapshot6.md >}}) back in May of this year. Since then we
+have worked hard to polish things up further and are therefore now able to present to you the first _release candidate_ (RC) of Mumble 1.4.0.
+
+You can download the new version from our [**Downloads page**]({{< relref "/downloads#development-snapshots" >}}).
+
+<!--more-->
+
+
+## Changelog
+
+The changes listed here are relative to the last snapshot version.
+
+### Client
+
+- Changed: Increased minimum macOS version to 10.13 (which is what Qt requires) {{< issue 5250 >}}
+- Changed: Display unit as suffix in SpinBox ({{< issue 5017 >}})
+- Changed: Do not play the mute cue when push-to-muted ({{< issue 5047 >}})
+- Changed: Resize posted images to 800x600 instead of 420x270 ({{< issue 5050 >}})
+- Fixed: Ambiguity in plugin installer ({{< issue 5123 >}})
+- Fixed: Application freeze when cancelling audio wizard ({{< issue 5083 >}})
+- Fixed: Crash when using the PipeWire audio backend ({{< issue 5080 >}})
+- Fixed: Issues when updating installed plugins on Windows ({{< issue 5167 >}})
+- Fixed: Migrate Windows shortcuts from versions older than 1.4.0 properly ({{< issue 5205 >}})
+- Fixed: PluginInstaller unable to extract zips on Windows ({{< issue 5109 >}})
+- Fixed: Positional audio not working properly after canceling audio wizard ({{< issue 5046 >}})
+- Fixed: Potential deadlocks in plugins ({{< issue 5163 >}})
+- Fixed: PulseAudio not initializing ({{< issue 5184 >}})
+- Fixed: Remove unnecessary waiting during application startup (Mumble now starts up way faster) ({{< issue 5168 >}})
+- Fixed: onAudioOutputAboutToPlay plugin API function used wrong parameter order ({{< issue 5115 >}})
+- Fixed: requestLocalUserTransmissionMode plugin API function now properly integrates with UI ({{< issue 5116 >}})
+
+
+### Server
+
+- Fixed: Always bind to both IPv6 and IPv4 by default ({{< issue 5212 >}})
+- Fixed: Database upgrade path ignoring specific data field ({{< issue 5142 >}})
+- Fixed: Missing lock in Ice-call setACL ({{< issue 5136 >}})
+- Fixed: Possible DB corruption due to missing locks ({{< issue 5044 >}})
+- Fixed: Tray icon not shown on Windows ({{< issue 5173 >}})
+- Fixed: Wrong "Unable to find matching CELT codec" warning upon connecting ({{< issue 5112 >}})
+
+
+### Positional audio plugins
+
+- Added: Update & port GTA5 to new Plugin API ({{< issue 5162 >}})
+- Fixed: Update Among Us plugin to work with v2021.6.30s ({{< issue 5189 >}})
+- Fixed: Update Source Engine plugin to work with L4D2 2.2.2.0 ({{< issue 5190 >}})
+
+
+## Known issues
+
+- Overlay blocked by BattleEye. A request to whitelist it has been made.
+- Overlay blocked by CS:GO Trusted Mode
+- Autoscroll of chat window not working properly on Linux ({{< issue 4638 >}}, {{< issue 2504 >}})
+- Certain special characters are not rendered on Windows ({{< issue 4939 >}})
+- The RC is still being displayed as a "snapshot"

--- a/hugo/content/documentation/user/positional-audio/supported-games.md
+++ b/hugo/content/documentation/user/positional-audio/supported-games.md
@@ -13,7 +13,7 @@ Mumble version 1.2 introduced additional, extended positional audio features. To
 
 Games and game engines that provide native support remain functional across game updates.
 
-*Developer reference: [See developer integration documentation]({{< relref "/documentation/developer/positional-audio/link-plugin/" >}})*
+*Developer reference: [See developer integration documentation]({{< relref "/documentation/developer/positional-audio/link-plugin" >}})*
 
 ### 3D/Game Engines With Native Support
 

--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -135,10 +135,10 @@ ourselves).
 Development snapshots contain unreleased features and changes that will eventually be available in the next stable release. Please report any problems
 you encounter on [our issue tracker](https://github.com/mumble-voip/mumble/issues).
 
-The most recent snapshot version is the sixth snapshot of Mumble version 1.4.0
-([Release Announcement]({{< relref "/blog/2021-05-16-mumble-1-4-0-snapshot6" >}})).
+The most recent snapshot version is actually the first release candidate for Mumble 1.4.0
+([Release Announcement]({{< relref "/blog/2021-09-12-mumble-release-candidate1" >}})).
 
-Note that we are currently not able to provide static server binaries for Linux or macOS nor are we able to provide a snapshot PPA for Linux just yet.
+Note that we are currently not able to provide static server binaries for Linux nor are we able to provide a snapshot PPA for Linux just yet.
 
 {{< content-layout/downloads >}}
 {{< content-layout/download name="Client for Windows (x64)" href="https://dl.mumble.info/latest/snapshot/client-windows-x64" osclass="windows">}}
@@ -149,11 +149,11 @@ Note that we are currently not able to provide static server binaries for Linux 
 
 {{< content-layout/downloads >}}
 {{< content-layout/download name="Client for macOS >= 10.13 (x64)" href="https://dl.mumble.info/latest/snapshot/client-macos-x64" osclass="mac">}}
-{{< content-layout/download name="Client for macOS <= 10.12 (x64)" href="https://dl.mumble.info/latest/snapshot/client-macos-hfs+-x64" osclass="mac">}}
+{{< content-layout/download name="Server for macOS >= 10.13 (x64)" href="https://dl.mumble.info/latest/snapshot/server-macos-x64" osclass="mac">}}
 {{< /content-layout/downloads >}}
 
-Note (macOS): Apple introduced a stricter verification and warning process. macOS will now warn you when installing the Mumble application. This is
-expected and not a security issue. Apple will not currently verify and acknowledge our package unless we pay. *(Issue tracked in {{< issue 4263 >}})*
+Note that we are no longer able to support macOS < 10.13 since [Qt does not support](https://doc.qt.io/qt-5/macos.html#supported-versions) these
+versions anymore.
 
 ## Source Code
 


### PR DESCRIPTION
I have the signed Windows and macOS binaries available. They just have to be uploaded when this goes live.

The first commit in this PR doesn't actually have anything to do with the RC but was something I had to fix in order to work on that. I figured I'll simply smuggle this in here.

TODO:
- [x] Upload binaries
- [x] Provide URL endpoint for macOS server