### PR TITLE
FR: Add feature requests page

### DIFF
--- a/hugo/content/contribute.md
+++ b/hugo/content/contribute.md
@@ -8,9 +8,13 @@ You can contribute to the Mumble Project in multiple ways:
 
 ## Report bugs and Feature Requests
 
-1. Take a look at existing [issues in our GitHub repo](https://github.com/mumble-voip/mumble/issues) to check whether your issue or request was already reported.
-   If that's the case, then vote for it with a thumbs up or add useful information & ideas with a comment.
-2. If there is no issue report yet, then create a [new one](https://github.com/mumble-voip/mumble/issues/new/choose).
+Take a look at our tracked [Feature Requests]({{< relref "/feature-requests" >}}) and vote for those that you would love to see with a thumbs up (👍) reaction on GitHub.
+
+For bug reports check our tracked [issues on GitHub](https://github.com/mumble-voip/mumble/issues) for existing ones, and to create new ones too.
+
+We depend on our community to report issues, to offer details about tracked issues, and sometimes to test potential solutions. You can look for issues you are interested in, you experience yourself, can provide details on, or help resolve.
+
+We also receive support requests as issues which you may be able to help and resolve by communicating with the help-seeker. Please refer to the [open support tickets](https://github.com/mumble-voip/mumble/issues?q=is%3Aopen+is%3Aissue+label%3Asupport), if there are any (they have the label *support*).
 
 **Note:** For security issues, see [Report a vulnerability]({{< relref "security#reporting-a-vulnerability" >}}).
 

--- a/hugo/content/feature-requests/index.md
+++ b/hugo/content/feature-requests/index.md
@@ -1,0 +1,7 @@
+---
+title: "Mumble Feature Requests"
+layout: "feature-requests"
+---
+The feature requests are submitted, voted on, discussed, and managed [in our issue tracker](https://github.com/mumble-voip/mumble/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc+).
+
+Don’t see a feature request for something that you would love to see? [Create a new feature request for it!](https://github.com/mumble-voip/mumble/issues/new?assignees=&labels=&template=feature_request.md&title=)

--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -9,6 +9,7 @@
         {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
     {{ partial "layout/header-css.html" . }}
+    {{ block "pagecss" . }}{{ end }}
 </head>
 <body>
     {{ partial "layout/header.html" . }}

--- a/hugo/layouts/_default/feature-requests.html
+++ b/hugo/layouts/_default/feature-requests.html
@@ -1,0 +1,79 @@
+{{ define "pagecss" }}
+<style>
+#feature-requests ul {
+    margin: 1.8em 0;
+}
+#feature-requests li {
+    list-style: none;
+    margin: 0 0 1rem 0;
+    line-height: 1.8em;
+}
+#feature-requests .title {
+    font-size: 1.4rem;
+}
+#feature-requests .labels span {
+    padding: 2px 8px;
+    color: #fff;
+    text-shadow: black 0 0 5px;
+    margin: 0 4px;
+}
+</style>
+{{ end }}
+{{ define "main" }}
+
+<div class="markdown-body">
+<h1>{{ .Title }}</h1>
+{{ .Content }}
+</div>
+<div id="feature-requests">Loading…</div>
+<script>
+function setFailure() {
+    target.innerText = 'Failed to load feature requests. Please refer to <a href="https://github.com/mumble-voip/mumble/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc+">the repository issues directly</a>.'
+}
+// obj: total_count incomplete_results
+//      items array
+//                  html_url number title state locked assignee comments body
+//                  labels array(name color description)
+//                  reactions obj(total_count +1 -1 laugh hooray confused heart rocket eyes)
+function handleResult(res) {
+    let target = document.getElementById('feature-requests')
+    let list = ''
+    for (let item of res.items) {
+        let labels = ''
+        for (let label of item.labels) {
+            labels += `<span style="background-color:#${label.color};" title="${label.description}">${label.name}</span>`
+        }
+        list += `<li>
+                <div class="title"><a href="${item.html_url}">${item.title} (#${item.number})</a></div>
+                <div class="">${item.comments} comments, ${item.reactions.total_count} reactions. ${item.reactions['+1']} 👍 (+1), ${item.reactions.heart} ❤️, ${item.reactions.rocket} 🚀, ${item.reactions.eyes} 👀</div>
+                <div class="labels">labels: ${labels}</div>
+            </li>`
+    }
+    target.innerHTML = `
+        <h1>Open Feature Requests (${res.total_count})</h1>
+        <ul>${list}</ul>
+        ${res.incomplete_results ? '<i>More in the tracker…' : ''}
+    `
+}
+function load() {
+    let req = new XMLHttpRequest()
+    if (!req) {
+        setFailure()
+        return false;
+    }
+    req.onreadystatechange = function() {
+        if (req.readyState === XMLHttpRequest.DONE) {
+            if (req.status === 200) {
+                let json = JSON.parse(req.responseText)
+                handleResult(json)
+            } else {
+                setFailure()
+            }
+        }
+    }
+    req.open('GET', 'https://api.github.com/search/issues?q=repo:mumble-voip/mumble+is:issue+label:feature-request+is:open+sort:reactions-%2B1-desc')
+    req.send()
+}
+load()
+</script>
+{{ end }}


### PR DESCRIPTION
Adds a feature request page that queries the GitHub Search API for our feature requests (anonymous request subject to rate limiting) and renders them as an ordered list.

> The Search API has a custom rate limit. For requests using Basic Authentication, OAuth, or client ID and secret, you can make up to 30 requests per minute. For unauthenticated requests, the rate limit allows you to make up to **10 requests per minute**.

Updates the contribute page to refer to it as well as the support label which was not mentioned before.

![image](https://user-images.githubusercontent.com/93181/138605791-cb0288ed-95bb-486b-b4dc-2eba7c463538.png)

Fixes #156