### PR TITLE
Add documentation toc

### DIFF
--- a/hugo/layouts/documentation/single.html
+++ b/hugo/layouts/documentation/single.html
@@ -1,0 +1,9 @@
+{{ define "main" }}
+
+<div class="markdown-body">
+<h1>{{ .Title }}</h1>
+{{- partial "toc.html" . -}}
+{{ .Content }}
+</div>
+
+{{ end }}


### PR DESCRIPTION
The documentation lacked a table of content. For starters, I simply added the existing toc.html

![image](https://user-images.githubusercontent.com/109021367/191447399-e1d81f1f-0eaa-4a5d-8fee-e9491691e93e.png)
