### PR TITLE
Add button “Edit on GitHub”

### DIFF
--- a/hugo/assets/css/content/_documentation.scss
+++ b/hugo/assets/css/content/_documentation.scss
@@ -1,9 +1,18 @@
-#page-title {
+#documentation-header {
     display: flex;
     flex-direction: row;
+    margin: 1em 0 .5em;
+    align-items: center;
+    padding-bottom: 0.3em;
+    border-bottom: 1px solid #eaecef;
+    justify-content: space-between;
+    #page-title {
+        margin: 0;
+        padding: 0;
+        border: 0;
+    }
     #page-edit-button {
-        font-size: .5em;
-        margin: auto 0 .25em auto;
+        font-size: 0.9rem;
         &:is(a) {
             color: grey;
         }

--- a/hugo/assets/css/content/_documentation.scss
+++ b/hugo/assets/css/content/_documentation.scss
@@ -1,0 +1,11 @@
+#page-title {
+    display: flex;
+    flex-direction: row;
+    #page-edit-button {
+        font-size: .5em;
+        margin: auto 0 .25em auto;
+        &:is(a) {
+            color: grey;
+        }
+    }
+}

--- a/hugo/assets/css/content/_documentation.scss
+++ b/hugo/assets/css/content/_documentation.scss
@@ -1,10 +1,10 @@
 #documentation-header {
     display: flex;
     flex-direction: row;
-    margin: 1em 0 .5em;
-    align-items: center;
+    margin: 1em 0;
+    align-items: flex-end;
     padding-bottom: 0.3em;
-    border-bottom: 1px solid #eaecef;
+    border-bottom: 1px solid var(--lt-color-border-default);
     justify-content: space-between;
     #page-title {
         margin: 0;
@@ -12,9 +12,24 @@
         border: 0;
     }
     #page-edit-button {
-        font-size: 0.9rem;
+        font-size: 0.8rem;
+        font-weight: bold;
+        border: 1px solid var(--lt-color-border-default);
+        border-radius: 1rem;
+        padding: 0.4rem 1rem 0.35rem 1rem;
+        line-height: normal;
+        text-decoration: none;
+        transition: 0.2s background-color, 0.15s color, 0.025s border;
         &:is(a) {
-            color: grey;
+            color: var(--lt-color-gray-500);
+        }
+        &:hover {
+            background-color: var(--lt-color-border-light);
+            color: var(--lt-color-gray-600);
+        }
+        &:active {
+            background-color: var(--lt-color-border-default);
+            color: var(--lt-color-gray-600);
         }
     }
 }

--- a/hugo/assets/css/main.scss
+++ b/hugo/assets/css/main.scss
@@ -1,6 +1,7 @@
 @import 'layout';
 
 @import 'content/blog/release-notes';
+@import 'content/documentation';
 @import 'content/downloads';
 @import 'content/home';
 @import 'content/sponsors';

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -7,6 +7,8 @@ disableKinds = ["taxonomy","taxonomyTerm"]
 
 [params]
   description = "Mumble is a free, open source, low latency, high quality voice chat application."
+  gitSite = "GitHub"
+  gitWebURL = "https://github.com/mumble-voip/mumble-www/"
 
 [permalinks]
   blog = "/blog/:title/"

--- a/hugo/layouts/documentation/single.html
+++ b/hugo/layouts/documentation/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 
 <div class="markdown-body">
-<h1>{{ .Title }}</h1>
+<h1 id="page-title">{{ .Title }} <a id="page-edit-button" href="{{ .Site.Params.gitWebURL }}edit/master/hugo/content/{{ .Page.File.Path }}">Edit on {{ .Site.Params.gitSite }}</a></h1>
 {{- partial "toc.html" . -}}
 {{ .Content }}
 </div>

--- a/hugo/layouts/documentation/single.html
+++ b/hugo/layouts/documentation/single.html
@@ -1,7 +1,11 @@
 {{ define "main" }}
 
 <div class="markdown-body">
-<h1 id="page-title">{{ .Title }} <a id="page-edit-button" href="{{ .Site.Params.gitWebURL }}edit/master/hugo/content/{{ .Page.File.Path }}">Edit on {{ .Site.Params.gitSite }}</a></h1>
+    <div id="documentation-header">
+        <h1 id="page-title">{{ .Title }}</h1>
+        <a id="page-edit-button" href="{{ .Site.Params.gitWebURL }}edit/master/hugo/content/{{ .Page.File.Path }}">Improve this page</a>
+    </div>
+
 {{- partial "toc.html" . -}}
 {{ .Content }}
 </div>


### PR DESCRIPTION
This adds the button “Edit on GitHub” on single pages in the Mumble documentation.

|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/109021367/208267402-c2aab8bd-bf88-4595-ba9f-165f4a5b8b32.png)|![after](https://user-images.githubusercontent.com/109021367/208267383-0b1c07b6-838b-407d-a4f7-50cacbbbcb18.png)|