### PR TITLE
docs(richtext): Add richtext HTML and CSS notes

### DIFF
--- a/hugo/content/documentation/html-and-css.md
+++ b/hugo/content/documentation/html-and-css.md
@@ -1,0 +1,12 @@
+---
+title: "HTML and CSS in Mumble"
+---
+HTML and CSS can be used for rich text markup, formatting, and styling in Mumble's rich text fields:
+
+* The welcome message of a server (server setting `welcometext`)
+* User comments
+* Channel descriptions
+* Text messages
+
+Mumble uses Qt rich text controls.
+The subset of allowed and interpreted HTML and CSS declarations can be found in the [Qt documentation *Supported HTML Subset*](https://doc.qt.io/qt-5/richtext-html-subset.html).


### PR DESCRIPTION
Replaces https://wiki.mumble.info/wiki/Usage_of_HTML_and_CSS_in_Mumble
