### PR TITLE
docs: Fix relref paths

### DIFF
--- a/hugo/content/documentation/developer/positional-audio/create-plugin/guide/index.md
+++ b/hugo/content/documentation/developer/positional-audio/create-plugin/guide/index.md
@@ -15,7 +15,7 @@ This guide is supposed to be a step-by-step tutorial for the general case. For a
 
 ### Programs needed
 
-[Analysis Tools]({{< relref "../memory-analysis-tools" >}})
+[Analysis Tools]({{< relref "memory-analysis-tools" >}})
 
 #### Tools
 

--- a/hugo/content/documentation/user/audio-settings/index.md
+++ b/hugo/content/documentation/user/audio-settings/index.md
@@ -81,7 +81,7 @@ This is intended to reduce noise being picked up while you talk, and you being a
 
 ### Positional Audio
 
-When enabled and when in-game with others, [Positional Audio]({{< relref "../positional-audio" >}}) allows you to hear them from the direction and distance they are in in-game.
+When enabled and when in-game with others, [Positional Audio]({{< relref "/documentation/user/positional-audio" >}}) allows you to hear them from the direction and distance they are in in-game.
 
 When people stand right next to you will hear them at full volume. The bloom setting defines how much directional audio blooms into other directions. If they stand to your right, the bloom will make it so you also hear a bit of them to your left. (Which makes sense when they are very close.)
 


### PR DESCRIPTION
These relative parent paths worked on hugo version 0.122.0 but not on 0.124.1.

The adjusted paths work on both.