### PR TITLE
Downloads: Fix required VC redist version reference

### DIFF
--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -74,7 +74,7 @@ document.getElementById('suggested-download').innerHTML = getPlatformContent(get
 
 ## Manual Download
 
-*Note: On Windows Microsoft Visual C++ 2022 Redistributable (<a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64 download</a>.*
+*Note: On Windows Microsoft Visual C++ 2022 Redistributable (<a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64 download</a> is required to be installed.*
 
 {{< content-layout/downloads >}}
 {{< content-layout/download name="Windows client (x64)" href="https://dl.mumble.info/latest/stable/client-windows-x64" osclass="windows">}}

--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -74,7 +74,7 @@ document.getElementById('suggested-download').innerHTML = getPlatformContent(get
 
 ## Manual Download
 
-*Note: On Windows Microsoft Visual C++ 2022 Redistributable (<a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64 download</a> and <a href="https://aka.ms/vs/17/release/vc_redist.x86.exe">x86 download</a>) is required to be installed.*
+*Note: On Windows Microsoft Visual C++ 2022 Redistributable (<a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64 download</a>.*
 
 {{< content-layout/downloads >}}
 {{< content-layout/download name="Windows client (x64)" href="https://dl.mumble.info/latest/stable/client-windows-x64" osclass="windows">}}

--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -50,7 +50,7 @@ function getButton(href, icon, caption) {
     return '<a class="suggested-download-button" href="' + href + '"><img class="suggested-download-button-icon" src="/css/icons/' + icon + '"><div class="suggested-download-button-caption">' + caption + '</div></a>'
 }
 function getWinRedistNotice() {
-    return '<div style="grid-row: 2; font-style: italic;">Requires installed Microsoft Visual C++ 2015-2022 Redistributable <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64</a> to run</div>'
+    return '<div style="grid-row: 2; font-style: italic;">Requires installed Microsoft Visual C++ 2022 Redistributable <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64</a> to run</div>'
 }
 function getPlatformContent(platform) {
     switch (platform) {
@@ -74,7 +74,7 @@ document.getElementById('suggested-download').innerHTML = getPlatformContent(get
 
 ## Manual Download
 
-*Note: On Windows Microsoft Visual C++ 2015-2022 Redistributable (<a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64 download</a> and <a href="https://aka.ms/vs/17/release/vc_redist.x86.exe">x86 download</a>) is required to be installed.*
+*Note: On Windows Microsoft Visual C++ 2022 Redistributable (<a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">x64 download</a> and <a href="https://aka.ms/vs/17/release/vc_redist.x86.exe">x86 download</a>) is required to be installed.*
 
 {{< content-layout/downloads >}}
 {{< content-layout/download name="Windows client (x64)" href="https://dl.mumble.info/latest/stable/client-windows-x64" osclass="windows">}}


### PR DESCRIPTION
Davide confirmed we require 2022.

Some more technical context: VC Redist is backwards compatible - 2022 is backwards compatible down to 2015.

https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-studio-2015-2017-2019-and-2022

With the 1.5 version, we no longer publish x86, so we drop that redist requirement mention too.