### PR TITLE
Fix link to Flathub

### DIFF
--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -119,7 +119,7 @@ A Snap package is published and maintained by the third party Snapcraft communit
 
 ### Flatpak
 
-A Flatpak Package is published and maintained by the third party Flatpak community at <https://www.flathub.org/apps/details/info.mumble.Mumble>
+A Flatpak Package is published and maintained by the third party Flatpak community at <https://flathub.org/apps/details/info.mumble.Mumble>
 
 ## Mobile Clients
 


### PR DESCRIPTION
https://www.flathub.org does not have a valid certificate, www. has to be removed.

So this replaces current https://www.flathub.org/apps/info.mumble.Mumble by https://flathub.org/apps/info.mumble.Mumble