### PR TITLE
Add docs network protocol link

### DIFF
--- a/hugo/content/documentation/developer/_index.md
+++ b/hugo/content/documentation/developer/_index.md
@@ -3,6 +3,6 @@ title: "Mumble Developer Documentation"
 ---
 A lot of the developer documentation can be found in the [Mumble repository docs subfolder](https://github.com/mumble-voip/mumble/tree/master/docs) as Markdown text documents.
 
-This includes some client documentation, but in [docs/dev](https://github.com/mumble-voip/mumble/tree/master/docs/dev) more technical documentation like [build instructions](https://github.com/mumble-voip/mumble/tree/master/docs/dev/build-instructions), source code, feature and concept documentation, and development workflow guidance.
+This includes some client documentation, but in [docs/dev](https://github.com/mumble-voip/mumble/tree/master/docs/dev) more technical documentation like [build instructions](https://github.com/mumble-voip/mumble/tree/master/docs/dev/build-instructions), [Mumble network protocol](https://github.com/mumble-voip/mumble/tree/master/docs/dev/network-protocol), source code, feature and concept documentation, and development workflow guidance.
 
 Apart from that documentation, referred to and linked above, this website hosts the following documentation and documentation categories.


### PR DESCRIPTION
Through https://github.com/mumble-voip/mumble/pull/6623 we migrated our separate network protocol documentation repository into our main project repository docs folder.