### PR TITLE
Add a line to tell location of mumble-server.ini

### DIFF
--- a/hugo/content/documentation/administration/config-file/index.md
+++ b/hugo/content/documentation/administration/config-file/index.md
@@ -20,6 +20,8 @@ via RPC.
 A unique example is ``port`` - the first server will attempt to bind to this port, with
 each subsequent server incrementing the port by one for its own port.
 
+For Windows user, you should create the ``mumble-server.ini`` file on C:\Users\YourUsername\AppData\Local\Mumble\Murmur
+
 ### ICE
 
 #### ``ice``


### PR DESCRIPTION
I tried to change the port of my local murmur server on windows and i spent a lot of time to find it.