### PR TITLE
docs(linux): Fix typo and update filename in linux overlay

### DIFF
--- a/hugo/content/documentation/user/in-game-overlay/linux.md
+++ b/hugo/content/documentation/user/in-game-overlay/linux.md
@@ -1,7 +1,7 @@
 ---
 title: "Mumble Overlay on Linux"
 ---
-To use the Overlay in an application you start that appliaction through the mumble-overlay binary:
+To use the Overlay in an application you start that application through the mumble-overlay binary:
 
 ```bash
 mumble-overlay gameexecutable
@@ -10,5 +10,5 @@ mumble-overlay gameexecutable
 The mumble-overlay binary is a utility for an *LD preload* which you can also execute manually:
 
 ```bash
-LD_PRELOAD=/path/to/libmumble.so.1.1 gameexecutable
+LD_PRELOAD=/path/to/libmumbleoverlay.so gameexecutable
 ```


### PR DESCRIPTION
I happened to notice the typo when trying to use the overlay.

I didn't find `libmumble.so.1.1` on my Fedora 44 Kinoite (beta), while a glance at `mumble-overlay` and quick search reveal that the library got renamed at some point, unless Fedora and Arch rename it by themselves for some reason.