### PR TITLE
Semantically expose release date

### DIFF
--- a/hugo/content/downloads.md
+++ b/hugo/content/downloads.md
@@ -4,7 +4,7 @@ title: Downloads
 We provide downloads for the official client and server programs. A Linux distribution may provide their own packages and have their own maintainer,
 which we will describe below. We also link to some third party projects.
 
-Version **1.5.857** is the latest stable version of Mumble and was released on October 10th, 2025.
+Version **1.5.857** is the latest stable version of Mumble and was released on <time datetime="2025-10-10">October 10th, 2025</time>.
 
 Note also when you upgrade from Mumble <= 1.3.x, you have to **uninstall Mumble manually** before installing 1.5, since the **upgrade path is unfixably broken**. See
 [here](https://github.com/mumble-voip/mumble/issues/5076) for more info.


### PR DESCRIPTION
While web browsers do not format the date according to user agent preferences, `<time>` makes it semantically parseable/more obvious. This could improve accessibility or other machine or tool interpretations.

It has a maintenance impact, though: It must be kept consistent between attribute and text content.

Another downside is the mixing of HTML into Markdown. Although this page already has HTML and JavaScript embedded.

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time

What do you think?