### PR TITLE
docs: Drop references to GitHub discussions

### DIFF
--- a/hugo/content/contact.md
+++ b/hugo/content/contact.md
@@ -7,7 +7,6 @@ You can contact us in several ways.
 ## Community Channels
 
 * [Issue tracker on GitHub](https://github.com/mumble-voip/mumble/issues)
-* [Discussions on GitHub](https://github.com/mumble-voip/mumble/discussions)
 * Chat [`#mumble:matrix.org`](https://matrix.to/#/#mumble:matrix.org)  
   usable with any Matrix chat client; for example [open with Element](https://app.element.io/#/room/#mumble:matrix.org)  
 


### PR DESCRIPTION
Discussions are turned off for the mumble project and the URL lead to a 404.