### PR TITLE
fix: Resolve unintended main nav layout line break

### DIFF
--- a/hugo/assets/css/_common.scss
+++ b/hugo/assets/css/_common.scss
@@ -24,6 +24,10 @@ ul.menu {
 	list-style-type: none;
 	margin: 0;
 	padding: 0;
+	display: flex;
+	gap: 0.5em;
+	flex-wrap: wrap;
+	justify-content: end;
 
 	li {
 		display: inline-block;
@@ -32,7 +36,7 @@ ul.menu {
 			display: inline-block;
 			color: black;
 			text-align: center;
-			padding: 14px 16px;
+			padding: 0.5em 0.3em;
 			text-decoration: none;
 
 			&:hover {

--- a/hugo/assets/css/layout/_header.scss
+++ b/hugo/assets/css/layout/_header.scss
@@ -35,7 +35,6 @@ body > #page-head {
 
 	nav {
 		grid-template: "nav";
-		text-align: right;
 		align-self: center;
 	}
 }
@@ -45,6 +44,10 @@ body > #page-head {
 	padding: 10px;
 	margin: auto;
 	display: grid;
-	grid-template-columns: auto auto 1fr;
-	grid-template-areas: "logo header nav";
+	grid-template-columns: auto auto minmax(1em,1fr) auto;
+	grid-template-areas: "logo header . nav";
+
+	> nav {
+		grid-area: nav;
+	}
 }

--- a/hugo/assets/css/main.scss
+++ b/hugo/assets/css/main.scss
@@ -8,12 +8,14 @@
 
 @media only screen and (max-width: 768px) {
 	#header-content {
-		display: block !important;
-		text-align: center !important;
+		text-align: center;
+		/* Transform grid from columns to rows */
+		grid-template-columns: auto;
+		grid-template-rows: auto auto 1em auto;
+		grid-template-areas: "logo"  "header"  "."  "nav";
+		/* Center content - looks better for a narrow screen */
+		justify-items: center;
 
-		.logo {
-			margin: 0 auto !important;
-		}
 		nav {
 			text-align: center !important;
 		}


### PR DESCRIPTION
On max width layout we rendered a nav items line break. We never showed the nav in one line in the desktop layout.

<img width="823" height="170" alt="image" src="https://github.com/user-attachments/assets/db0af6fd-76fa-4ffd-b7c2-e2fe85951e24" />

* Rework `ul.menu` into flex grid
  * Change from `a` padding to narrower padding and gaps
* Clean up and adjust narrow-viewport declarations
  * Clear out unnecessary `!important` declarations

Before:

https://github.com/user-attachments/assets/bff6deca-9d6f-4f2b-a843-f4ccc2e3a31b

After:

https://github.com/user-attachments/assets/12d9ff73-314c-408f-9748-376c2cce9b27
