### PR TITLE
CI: Only deploy artifacts build on the master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
     workflows: [ 'Build Hugo files' ]
     types:
       - completed
+    branches:
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
Previously, we would publish every PR artifact